### PR TITLE
Update `loader-utils` to `v0.2.16`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "svgo": ">=0.4.0"
   },
   "dependencies": {
-    "loader-utils": "^0.2.5"
+    "loader-utils": "^0.2.16"
   }
 }


### PR DESCRIPTION
This allows `query` to be an actual object and makes things compatible with `webpack@2`.
