### PR TITLE
Allow Interpolation in Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,38 @@ module.exports = {
   }
 }
 ```
+
+### Interpolation
+
+Interpolation is allowed in the svgo configuration.  This is useful when using the [cleanupIDs](https://github.com/svg/svgo/blob/master/plugins/cleanupIDs.js) plugin, allowing a prefix to be added to id's to make them unique.
+
+See [loader-utils](https://github.com/webpack/loader-utils#interpolatename) for interpolation options.
+
+``` javascript
+// webpack.config.js
+
+var svgoConfig = JSON.stringify({
+  plugins: [
+    {
+        cleanupIDs: {
+            prefix: '[name]-'
+        }
+    }
+  ]
+});
+
+module.exports = {
+  ...
+  module: {
+    loaders: [
+      {
+        test: /.*\.svg$/,
+        loaders: [
+          'file-loader',
+          'svgo-loader?' + svgoConfig
+        ]
+      }
+    ]
+  }
+}
+```

--- a/example/interpolate/entry.js
+++ b/example/interpolate/entry.js
@@ -1,0 +1,1 @@
+require('./example.svg');

--- a/example/interpolate/example.svg
+++ b/example/interpolate/example.svg
@@ -1,0 +1,13 @@
+<svg width="80px" height="30px" viewBox="0 0 80 30"
+     xmlns="http://www.w3.org/2000/svg">
+
+  <defs>
+    <linearGradient id="Gradient01">
+      <stop offset="20%" stop-color="#39F" />
+      <stop offset="90%" stop-color="#F3F" />
+    </linearGradient>
+  </defs>
+
+  <rect x="10" y="10" width="60" height="10"
+        fill="url(#Gradient01)" />
+</svg>

--- a/example/interpolate/webpack.config.js
+++ b/example/interpolate/webpack.config.js
@@ -1,0 +1,24 @@
+var svgoConfig = JSON.stringify({
+  plugins: [
+    {cleanupIDs: {
+        prefix: '[name].[hash:6]-'
+    }}
+  ]
+});
+
+module.exports = {
+  context: __dirname,
+  entry: "./entry",
+  output: {
+    path: __dirname + "/dist",
+    filename: "bundle.js"
+  },
+  module: {
+    loaders: [
+      {
+        test: /.*\.svg$/,
+        loaders: ['file-loader', '../../index.js?' + svgoConfig]
+      }
+    ]
+  }
+}

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ module.exports = function(source) {
   this.cacheable(true);
   var callback = this.async();
 
-  var config = loaderUtils.parseQuery(this.query);
+  var interpolateQuery = loaderUtils.interpolateName(this, this.query, { content: source });
+  var config = loaderUtils.parseQuery(interpolateQuery);
 
   if (config.useConfig) {
     var configName = config.useConfig;


### PR DESCRIPTION
Allowing interpolation is useful when using the [cleanupIDs](https://github.com/svg/svgo/blob/master/plugins/cleanupIDs.js) plugin, allowing a prefix to be added to id's to make them unique.

See [loader-utils](https://github.com/webpack/loader-utils#interpolatename) for interpolation options.

``` javascript
// webpack.config.js

var svgoConfig = JSON.stringify({
  plugins: [
    {
        cleanupIDs: {
            prefix: '[name]-'
        }
    }
  ]
});

module.exports = {
  ...
  module: {
    loaders: [
      {
        test: /.*\.svg$/,
        loaders: [
          'file-loader',
          'svgo-loader?' + svgoConfig
        ]
      }
    ]
  }
}
```
