### PR TITLE
Support for loaderUtils.getOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function(source) {
   this.cacheable(true);
   var callback = this.async();
 
-  var config = loaderUtils.getOptions ? loaderUtils.getOptions(this) : loaderUtils.parseQuery(this.query);
+  var config = loaderUtils.getOptions(this);
 
   // This piece of code exists in order to support webpack 1.x.x top level configurations.
   // In webpack 2 this options does not exists anymore.

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function(source) {
   this.cacheable(true);
   var callback = this.async();
 
-  var config = loaderUtils.parseQuery(this.query);
+  var config = loaderUtils.getOptions ? loaderUtils.getOptions(this) : loaderUtils.parseQuery(this.query);
 
   // This piece of code exists in order to support webpack 1.x.x top level configurations.
   // In webpack 2 this options does not exists anymore.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "svgo": ">=0.4.0"
   },
   "dependencies": {
-    "loader-utils": "^0.2.16"
+    "loader-utils": "^0.2.16 || ^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "svgo": ">=0.4.0"
   },
   "dependencies": {
-    "loader-utils": "^0.2.16 || ^1.0.3"
+    "loader-utils": "^1.0.3"
   }
 }


### PR DESCRIPTION
I'm not 100% sure that the semver constraint should be like that, maybe `^1.0.3` is enough by itself.

Since this would at least require a minor-version bump, all packages installing this would check and see that there's 1.0.3 and would get it instead of 0.2.17. All other packages will still be using 0.2.16-17 without this change. So this code would always run with `loader-utils@1.0.3` that does have `getOptions`.

So I kept it now for clarity reasons, but as I mentioned, I think it's also safe to remove it.

Solves #10 