### PR TITLE
Fix peer dependencies warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,8 @@
     "file-loader": "^0.8.1",
     "webpack": "^1.4.13"
   },
-  "peerDependencies": {
-    "svgo": ">=0.4.0"
-  },
   "dependencies": {
-    "loader-utils": "^1.0.3"
+    "loader-utils": "^1.0.3",
+    "svgo": ">=0.4.0"
   }
 }


### PR DESCRIPTION
This patch fixes wrong dependencies
`warning "svgo-loader@1.2.1" has unmet peer dependency "svgo@>=0.4.0".`

`svgo` should be in real dependencies, not in peer, because this package require itself.
The first line in `index.js`:
```js
var Svgo = require('svgo');
```