### PR TITLE
Use new `svgo.optimize()` promise syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,12 +24,14 @@ module.exports = function(source) {
   }
 
   var svgo = new Svgo(config);
-  svgo.optimize(source, function(result) {
+  svgo.optimize(source)
+  .then(function(result) {
     if (result.error) {
       callback(new Error(result.error));
       return;
     }
 
     callback(null, result.data);
+    return;
   });
 };

--- a/index.js
+++ b/index.js
@@ -26,12 +26,14 @@ module.exports = function(source) {
   var svgo = new Svgo(config);
   svgo.optimize(source)
   .then(function(result) {
-    if (result.error) {
-      callback(new Error(result.error));
+    callback(null, result.data);
+    return;
+  }, function(error) {
+    if (error instanceof Error) {
+      callback(error);
       return;
     }
-
-    callback(null, result.data);
+    callback(new Error(error));
     return;
   });
 };


### PR DESCRIPTION
In the [newest version](https://github.com/svg/svgo/blob/master/lib/svgo.js) of the svgo code, there's a refactored version of the `.optimize()` method. When this new version lands, this should fix the breakage.
