### PR TITLE
Supply additional file information when optimizing an SVG to allow ID prefixing based on file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function(source) {
   }
 
   var svgo = new Svgo(config);
-  svgo.optimize(source, { input: 'file', path: this.resourcePath })
+  svgo.optimize(source, { path: this.resourcePath })
   .then(function(result) {
     callback(null, result.data);
     return;

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function(source) {
   }
 
   var svgo = new Svgo(config);
-  svgo.optimize(source)
+  svgo.optimize(source, { input: 'file', path: this.resourcePath })
   .then(function(result) {
     callback(null, result.data);
     return;


### PR DESCRIPTION
The SVGO library recently added a new "prefixIds" plugin, which included support for supplying additional file information to its optimize function so that ID prefixes could be created using a file's name. This will allow us to pass along this additional information from svgo-loader so that we can generate prefixes based on filename for SVGs loaded via this loader.

The info object I added is structured in the same way as the one in SVGO itself when optimizing files:

https://github.com/svg/svgo/blob/master/lib/svgo/coa.js#L377

And here is where this information is being used by the new prefixIds plugin:

https://github.com/svg/svgo/blob/master/plugins/prefixIds.js#L126